### PR TITLE
Define Todo TypeScript types and compile-time type test

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test": "tsc --noEmit"
   },
   "dependencies": {
     "next": "16.1.6",

--- a/src/types/todo.test.ts
+++ b/src/types/todo.test.ts
@@ -1,0 +1,18 @@
+import type { Todo } from "./todo";
+
+const validTodo: Todo = {
+  id: crypto.randomUUID(),
+  title: "Buy milk",
+  completed: false,
+  createdAt: new Date().toISOString(),
+};
+
+const alsoValidTodo = {
+  id: "b6b9434f-a524-43fb-bf10-295198f68fdf",
+  title: "Walk the dog",
+  completed: true,
+  createdAt: "2026-01-01T00:00:00.000Z",
+} satisfies Todo;
+
+void validTodo;
+void alsoValidTodo;

--- a/src/types/todo.ts
+++ b/src/types/todo.ts
@@ -1,0 +1,25 @@
+/**
+ * Represents a single todo item in the application.
+ */
+export interface Todo {
+  /**
+   * Unique identifier for a todo item (generated with crypto.randomUUID()).
+   */
+  id: string;
+
+  /**
+   * User-provided todo title, trimmed and limited to 300 characters.
+   */
+  title: string;
+
+  /**
+   * Completion state of the todo item.
+   * Defaults to false when a new todo is created.
+   */
+  completed: boolean;
+
+  /**
+   * Creation timestamp in ISO 8601 string format.
+   */
+  createdAt: string;
+}


### PR DESCRIPTION
[Developer] Closes #7

## Summary
- add exported Todo interface in src/types/todo.ts
- document all fields with JSDoc comments
- add compile-time type-check test in src/types/todo.test.ts
- add npm test script (tsc --noEmit)

## Tests
- npm test