### PR TITLE
Build TodoItem component with inline edit mode

### DIFF
--- a/src/components/TodoItem.test.tsx
+++ b/src/components/TodoItem.test.tsx
@@ -1,0 +1,136 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import TodoItem from "./TodoItem";
+import type { Todo } from "@/src/types/todo";
+
+afterEach(() => {
+  cleanup();
+});
+
+const todo: Todo = {
+  id: "todo-1",
+  title: "Original title",
+  completed: false,
+  createdAt: "2026-01-01T00:00:00.000Z",
+};
+
+const makeProps = (overrides: Record<string, unknown> = {}) => ({
+  todo,
+  isEditing: false,
+  onStartEdit: vi.fn(),
+  onEdit: vi.fn(),
+  onCancelEdit: vi.fn(),
+  onToggle: vi.fn(),
+  onDelete: vi.fn(),
+  error: null,
+  ...overrides,
+});
+
+describe("TodoItem", () => {
+  it("renders todo title and action buttons", () => {
+    const props = makeProps();
+    render(<TodoItem {...props} />);
+
+    expect(screen.getByText("Original title")).toBeInTheDocument();
+    expect(screen.getByLabelText("Edit todo")).toBeInTheDocument();
+    expect(screen.getByLabelText("Delete todo")).toBeInTheDocument();
+  });
+
+  it("enters edit mode on pencil click (calls onStartEdit)", () => {
+    const props = makeProps();
+    render(<TodoItem {...props} />);
+
+    fireEvent.click(screen.getByLabelText("Edit todo"));
+
+    expect(props.onStartEdit).toHaveBeenCalledWith("todo-1");
+  });
+
+  it("pre-fills input with current title", () => {
+    const props = makeProps({ isEditing: true });
+    render(<TodoItem {...props} />);
+
+    expect(screen.getByLabelText("Edit todo title")).toHaveValue("Original title");
+  });
+
+  it("calls onEdit with trimmed title on Enter", () => {
+    const props = makeProps({ isEditing: true });
+    render(<TodoItem {...props} />);
+
+    const input = screen.getByLabelText("Edit todo title");
+    fireEvent.change(input, { target: { value: "  Updated  " } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(props.onEdit).toHaveBeenCalledWith("todo-1", "Updated");
+  });
+
+  it("calls onEdit with trimmed title on Save click", () => {
+    const props = makeProps({ isEditing: true });
+    render(<TodoItem {...props} />);
+
+    const input = screen.getByLabelText("Edit todo title");
+    fireEvent.change(input, { target: { value: "  Updated  " } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(props.onEdit).toHaveBeenCalledWith("todo-1", "Updated");
+  });
+
+  it("calls onCancelEdit on Escape", () => {
+    const props = makeProps({ isEditing: true });
+    render(<TodoItem {...props} />);
+
+    const input = screen.getByLabelText("Edit todo title");
+    fireEvent.keyDown(input, { key: "Escape" });
+
+    expect(props.onCancelEdit).toHaveBeenCalled();
+  });
+
+  it("calls onCancelEdit on Cancel click", () => {
+    const props = makeProps({ isEditing: true });
+    render(<TodoItem {...props} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(props.onCancelEdit).toHaveBeenCalled();
+  });
+
+  it("does not call onEdit for empty input", () => {
+    const props = makeProps({ isEditing: true });
+    render(<TodoItem {...props} />);
+
+    const input = screen.getByLabelText("Edit todo title");
+    fireEvent.change(input, { target: { value: "" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(props.onEdit).not.toHaveBeenCalled();
+  });
+
+  it("does not call onEdit for whitespace-only input", () => {
+    const props = makeProps({ isEditing: true });
+    render(<TodoItem {...props} />);
+
+    const input = screen.getByLabelText("Edit todo title");
+    fireEvent.change(input, { target: { value: "   " } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(props.onEdit).not.toHaveBeenCalled();
+  });
+
+  it("shows character counter when > 250 chars", () => {
+    const props = makeProps({ isEditing: true });
+    render(<TodoItem {...props} />);
+
+    fireEvent.change(screen.getByLabelText("Edit todo title"), {
+      target: { value: "a".repeat(251) },
+    });
+
+    expect(screen.getByText("251/300")).toBeInTheDocument();
+  });
+
+  it("shows error when error prop set", () => {
+    const props = makeProps({ isEditing: true, error: "Storage full" });
+    render(<TodoItem {...props} />);
+
+    expect(screen.getByRole("alert")).toHaveTextContent("Storage full");
+  });
+});

--- a/src/components/TodoItem.tsx
+++ b/src/components/TodoItem.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { KeyboardEvent, useEffect, useState } from "react";
+
+import type { Todo } from "@/src/types/todo";
+
+interface TodoItemProps {
+  todo: Todo;
+  isEditing: boolean;
+  onStartEdit: (id: string) => void;
+  onEdit: (id: string, newTitle: string) => void;
+  onCancelEdit: () => void;
+  onToggle: (id: string) => void;
+  onDelete: (id: string) => void;
+  error?: string | null;
+}
+
+const MAX_LENGTH = 300;
+
+export default function TodoItem({
+  todo,
+  isEditing,
+  onStartEdit,
+  onEdit,
+  onCancelEdit,
+  onToggle,
+  onDelete,
+  error = null,
+}: TodoItemProps) {
+  const [draftTitle, setDraftTitle] = useState(todo.title);
+
+  useEffect(() => {
+    if (isEditing) {
+      setDraftTitle(todo.title);
+    }
+  }, [isEditing, todo.title]);
+
+  const submitEdit = () => {
+    const trimmed = draftTitle.trim();
+    if (!trimmed) {
+      return;
+    }
+
+    onEdit(todo.id, trimmed);
+  };
+
+  const handleEditKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "Enter") {
+      submitEdit();
+      return;
+    }
+
+    if (event.key === "Escape") {
+      setDraftTitle(todo.title);
+      onCancelEdit();
+    }
+  };
+
+  return (
+    <li>
+      <input
+        type="checkbox"
+        checked={todo.completed}
+        onChange={() => onToggle(todo.id)}
+        aria-label={`Toggle ${todo.title}`}
+      />
+
+      {isEditing ? (
+        <div>
+          <input
+            aria-label="Edit todo title"
+            value={draftTitle}
+            onChange={(event) => setDraftTitle(event.target.value)}
+            onKeyDown={handleEditKeyDown}
+            maxLength={MAX_LENGTH}
+          />
+          <button type="button" onClick={submitEdit}>
+            Save
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              setDraftTitle(todo.title);
+              onCancelEdit();
+            }}
+          >
+            Cancel
+          </button>
+          {draftTitle.length > 250 ? <p>{`${draftTitle.length}/${MAX_LENGTH}`}</p> : null}
+          {error ? (
+            <p role="alert" style={{ color: "red" }}>
+              {error}
+            </p>
+          ) : null}
+        </div>
+      ) : (
+        <>
+          <span>{todo.title}</span>
+          <button type="button" aria-label="Edit todo" onClick={() => onStartEdit(todo.id)}>
+            ✏️
+          </button>
+        </>
+      )}
+
+      <button type="button" aria-label="Delete todo" onClick={() => onDelete(todo.id)}>
+        Delete
+      </button>
+    </li>
+  );
+}
+
+export type { TodoItemProps };


### PR DESCRIPTION
[Developer] Closes #13

## Summary
- add TodoItem client component in src/components/TodoItem.tsx
- render checkbox, title, edit trigger, and delete action
- support parent-controlled edit mode via isEditing
- in edit mode, prefill input with current title and enforce maxLength=300
- submit edits on Enter or Save with trimmed title
- reject empty/whitespace edits without calling onEdit
- support cancel on Escape and Cancel button
- show character counter when input length > 250
- show inline red error message when error prop is provided
- preserve edit input when error is shown
- add tests in src/components/TodoItem.test.tsx

## Tests
- npm test